### PR TITLE
Skip children

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,5 +38,8 @@ jobs:
       - name: Install Dependencies
         run: npm i
 
+      - name: Build
+        run: npm run build:dev
+
       - name: Run Tests
         run: npm test

--- a/lib/Path.ts
+++ b/lib/Path.ts
@@ -4,6 +4,7 @@ import never from 'never'
 class Path {
   node: Node
   parentPath?: Path
+  skipChildren = false
 
   constructor (node: Node, parentPath?: Path) {
     this.node = node

--- a/lib/traverse.ts
+++ b/lib/traverse.ts
@@ -9,20 +9,22 @@ const traverse = (node: Node, visitor: Visitor, parentPath?: Path): Path => {
   // Entering node
   visitor[path.node.type]?.enter?.(path)
 
-  // Possible sub nodes
-  switch (path.node.type) {
-    case 'Array':
-      path.node.elements.forEach(node => {
-        traverse(node, visitor, path)
-      })
-      break
-    case 'Object':
-      path.node.entries.forEach(node => {
-        traverse(node, visitor, path)
-      })
-      break
-    case 'ObjectEntry':
-      traverse(path.node.value, visitor, path)
+  if (!path.skipChildren) {
+    // Possible sub nodes
+    switch (path.node.type) {
+      case 'Array':
+        path.node.elements.forEach(node => {
+          traverse(node, visitor, path)
+        })
+        break
+      case 'Object':
+        path.node.entries.forEach(node => {
+          traverse(node, visitor, path)
+        })
+        break
+      case 'ObjectEntry':
+        traverse(path.node.value, visitor, path)
+    }
   }
 
   // Exiting node

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "build:umd": "tsc --project tsconfig/umd",
     "build:es": "tsc --project tsconfig/es",
     "build": "npm run build:umd && npm run build:es",
-    "test": "tsc && mocha dist/test",
+    "build:dev": "tsc",
+    "test": "mocha dist/test",
     "prepack": "npm run build"
   },
   "repository": {

--- a/test/traverse.ts
+++ b/test/traverse.ts
@@ -143,3 +143,35 @@ it('Replace node', () => {
     value: 2
   })
 })
+
+it('Skip children', () => {
+  const arrayEnterSpy = spy<VisitorEnter>(path => {
+    path.skipChildren = true
+  })
+  const arrayExitSpy = spy()
+  const numberEnterSpy = spy()
+  const numberExitSpy = spy()
+
+  traverse({
+    type: 'Array',
+    elements: [{
+      type: 'Number',
+      value: 3
+    }]
+  }, {
+    Array: {
+      enter: arrayEnterSpy,
+      exit: arrayExitSpy
+    },
+    Number: {
+      enter: numberEnterSpy,
+      exit: numberExitSpy
+    }
+  })
+
+  strictEqual(arrayEnterSpy.calledOnce, true)
+  strictEqual(arrayExitSpy.calledImmediatelyAfter(arrayEnterSpy), true)
+  strictEqual(arrayExitSpy.calledOnce, true)
+  strictEqual(numberEnterSpy.notCalled, true)
+  strictEqual(numberExitSpy.notCalled, true)
+})


### PR DESCRIPTION
By changing `path.skipChildren` to `true`, no children nodes will be traversed.